### PR TITLE
Remove totoval prefix from environment variables

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -18,7 +18,6 @@ func init() {
 		panic(fmt.Errorf("Fatal error config file: %s \n", err))
 	}
 
-	v.SetEnvPrefix("totoval")
 	v.AutomaticEnv()
 }
 


### PR DESCRIPTION
Previously, it was required to prefix all environment variables with "TOTOVAL_" in order to have an effect. This change removes the need for that prefix, so that the environment variables can have the same name as they have in the program and the configuration file.